### PR TITLE
fix: restore config breakdown modal functionality

### DIFF
--- a/web/frontend/js/app.js
+++ b/web/frontend/js/app.js
@@ -59,11 +59,6 @@ class ArcaneAuditorApp {
         }
 
         // Upload button listeners
-        const uploadBtn = document.getElementById('upload-btn');
-        if (uploadBtn) {
-            uploadBtn.addEventListener('click', () => this.uploadAndAnalyze());
-        }
-
         const uploadFilesBtn = document.getElementById('upload-files-btn');
         if (uploadFilesBtn) {
             uploadFilesBtn.addEventListener('click', () => this.uploadAndAnalyze());

--- a/web/frontend/style.css
+++ b/web/frontend/style.css
@@ -2396,3 +2396,342 @@ box-shadow: 0 2px 6px rgba(129, 140, 248, 0.25);
     font-weight: 500;
     font-size: 0.9rem;
 }
+
+/* Configuration Breakdown Modal Styles */
+#config-breakdown-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.modal-content {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    max-width: 800px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    border-radius: 12px 12px 0 0;
+}
+
+.modal-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.modal-close:hover {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.modal-body {
+    padding: 24px;
+}
+
+.config-breakdown-section {
+    margin-bottom: 24px;
+}
+
+.config-breakdown-section:last-child {
+    margin-bottom: 0;
+}
+
+.config-breakdown-section h4 {
+    margin: 0 0 16px 0;
+    color: var(--text-primary);
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.config-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.summary-card {
+    padding: 16px;
+    border-radius: 8px;
+    text-align: center;
+    border: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summary-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.summary-card.enabled {
+    border-left: 4px solid #10b981;
+    background: rgba(16, 185, 129, 0.05);
+}
+
+.summary-card.disabled {
+    border-left: 4px solid #64748b;
+    background: rgba(100, 116, 139, 0.05);
+}
+
+/* Light mode disabled summary cards - orange theme */
+[data-theme="light"] .summary-card.disabled {
+    border-left: 4px solid #ea580c;
+    background: rgba(251, 146, 60, 0.05);
+}
+
+.summary-card.total {
+    border-left: 4px solid #64748b;
+    background: rgba(100, 116, 139, 0.05);
+}
+
+.summary-number {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.summary-label {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.rule-breakdown {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 12px;
+}
+
+.rule-item {
+    padding: 16px;
+    padding-bottom: 2.5rem; /* space for bottom badges */
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-tertiary);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+}
+
+.rule-item:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.rule-item.enabled {
+    border-left: 4px solid #10b981;
+    background: rgba(16, 185, 129, 0.05);
+}
+
+.rule-item.disabled {
+    border-left: 4px solid #64748b;
+    background: rgba(100, 116, 139, 0.05);
+}
+
+/* Light mode disabled rule items - orange theme */
+[data-theme="light"] .rule-item.disabled {
+    border-left: 4px solid #ea580c;
+    background: rgba(251, 146, 60, 0.05);
+}
+
+.rule-header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 8px;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.rule-name {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 1rem;
+    flex: 1;
+    min-width: 0;
+    word-break: break-word;
+}
+
+.rule-status-badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+/* Prevent rule status badges from overlapping config settings */
+.rule-item .rule-status-badge {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+}
+
+.rule-status-badge.enabled {
+    background: rgba(16, 185, 129, 0.1);
+    color: #059669;
+    border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.rule-status-badge.disabled {
+    background: rgba(100, 116, 139, 0.1);
+    color: #64748b;
+    border: 1px solid rgba(100, 116, 139, 0.2);
+}
+
+/* Light mode disabled badges - orange theme */
+[data-theme="light"] .rule-status-badge.disabled {
+    background: rgba(251, 146, 60, 0.1);
+    color: #ea580c;
+    border: 1px solid rgba(251, 146, 60, 0.2);
+}
+
+.rule-description {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    margin-bottom: 8px;
+}
+
+/* Ensure disabled rules have the same text color as enabled rules */
+.rule-item.disabled .rule-name {
+    color: var(--text-primary);
+}
+
+.rule-item.disabled .rule-description {
+    color: var(--text-secondary);
+}
+
+.rule-settings {
+    margin-top: 12px;
+    margin-bottom: 20px;
+    padding: 12px;
+    background: var(--bg-primary);
+    border-radius: 6px;
+    border: 1px solid var(--border-color);
+}
+
+/* All badges should be positioned in the bottom corner */
+.rule-item .rule-status-badge {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+}
+
+.settings-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
+    margin-bottom: 8px;
+}
+
+.settings-json {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-size: 0.75rem;
+    color: var(--text-primary);
+    background: var(--bg-secondary);
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+/* Responsive adjustments for modal */
+@media (max-width: 1024px) {
+    .rule-breakdown {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+}
+
+@media (max-width: 768px) {
+    #config-breakdown-modal {
+        padding: 10px;
+    }
+    
+    .modal-content {
+        max-height: 95vh;
+    }
+    
+    .modal-header {
+        padding: 16px 20px;
+    }
+    
+    .modal-header h3 {
+        font-size: 1.1rem;
+    }
+    
+    .modal-body {
+        padding: 20px;
+    }
+    
+    .config-summary-grid {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+    
+    .rule-breakdown {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+    
+    .rule-header-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+    
+    .rule-name {
+        flex: none;
+        width: 100%;
+        margin-bottom: 4px;
+    }
+    
+    .rule-status-badge {
+        align-self: flex-start;
+    }
+}


### PR DESCRIPTION
- Restore comprehensive config breakdown modal from original single JS file
- Fix badge positioning to prevent overlapping with custom settings
- Add proper 2-column grid layout for rules display
- Implement orange theme for disabled rules in light mode
- Fix results page color conflicts that were overriding summary colors
- Clean up dead code and unused CSS/JS references

Fixes #21